### PR TITLE
Add '/messages' endpoint to client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "elm": "^0.18.0",
     "elm-analyse": "^0.13.3",
-    "elm-format": "^0.6.1-alpha",
+    "elm-format": "^0.7.0-exp",
     "elm-test": "^0.18.12"
   }
 }

--- a/src/Nexosis/Api/Data.elm
+++ b/src/Nexosis/Api/Data.elm
@@ -28,7 +28,7 @@ import Nexosis.Encoders.Columns exposing (encodeColumnMetadataList, encodeKeyCol
 import Nexosis.Types.Columns exposing (ColumnMetadata, DataType(..))
 import Nexosis.Types.DataSet exposing (DataSetData, DataSetList, DataSetName, DataSetStats, dataSetNameToString)
 import Nexosis.Types.SortParameters exposing (SortDirection(..), SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
+import NexosisHelpers exposing (addHeaders, pageParams, sortParams)
 import Set
 
 
@@ -49,12 +49,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-        (getBaseUrl config ++ "/data")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeDataSetList
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeDataSetList
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET a single `DataSet`, with paging on the actual contents of the `DataSet`.
@@ -65,12 +65,12 @@ getRetrieveDetail config name pgNum pgSize =
         params =
             pageParams pgNum pgSize
     in
-        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeDataSetData
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeDataSetData
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET data from a `DataSet` filtered by a specific date range. Used for time-series `DataSets`.
@@ -84,12 +84,12 @@ getDataByDateRange config name dateRange include =
                 ++ includeParams include
                 ++ [ ( "formatDates", "true" ) ]
     in
-        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeDataSetData
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeDataSetData
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET stats information about a specific `DataSet`.
@@ -124,11 +124,11 @@ delete config name cascadeOptions =
             Set.toList cascadeOptions
                 |> List.map (\c -> ( "cascade", c ))
     in
-        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-            |> HttpBuilder.delete
-            |> HttpBuilder.withQueryParams cascadeList
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+        |> HttpBuilder.delete
+        |> HttpBuilder.withQueryParams cascadeList
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| PUT - Upserts data to a dataset. If the `DataSet` has a key column, rows with the same key will be overwritten. If not, all rows will be appended to the existing `DataSet`.
@@ -189,11 +189,11 @@ createDataSetWithKey config dataSetName keyName =
         keyBody =
             Json.Encode.object [ ( "columns", encodeKeyColumnMetadata keyName ) ]
     in
-        (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
-            |> HttpBuilder.put
-            |> addHeaders config
-            |> HttpBuilder.withJsonBody keyBody
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
+        |> HttpBuilder.put
+        |> addHeaders config
+        |> HttpBuilder.withJsonBody keyBody
+        |> HttpBuilder.toRequest
 
 
 dataTypeToString : DataType -> String
@@ -212,11 +212,11 @@ setMissingValues config dataSetName missingValues =
         missingValuesBody =
             Json.Encode.object [ ( "missingValues", encodeMissingValues missingValues ) ]
     in
-        (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
-            |> HttpBuilder.put
-            |> addHeaders config
-            |> HttpBuilder.withJsonBody missingValuesBody
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
+        |> HttpBuilder.put
+        |> addHeaders config
+        |> HttpBuilder.withJsonBody missingValuesBody
+        |> HttpBuilder.toRequest
 
 
 encodeMissingValues : List String -> Json.Encode.Value

--- a/src/Nexosis/Api/Data.elm
+++ b/src/Nexosis/Api/Data.elm
@@ -49,12 +49,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-    (getBaseUrl config ++ "/data")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeDataSetList
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeDataSetList
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET a single `DataSet`, with paging on the actual contents of the `DataSet`.
@@ -65,12 +65,12 @@ getRetrieveDetail config name pgNum pgSize =
         params =
             pageParams pgNum pgSize
     in
-    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeDataSetData
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeDataSetData
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET data from a `DataSet` filtered by a specific date range. Used for time-series `DataSets`.
@@ -84,12 +84,12 @@ getDataByDateRange config name dateRange include =
                 ++ includeParams include
                 ++ [ ( "formatDates", "true" ) ]
     in
-    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeDataSetData
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeDataSetData
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET stats information about a specific `DataSet`.
@@ -124,11 +124,11 @@ delete config name cascadeOptions =
             Set.toList cascadeOptions
                 |> List.map (\c -> ( "cascade", c ))
     in
-    (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
-        |> HttpBuilder.delete
-        |> HttpBuilder.withQueryParams cascadeList
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data/" ++ uriEncodeDataSetName name)
+            |> HttpBuilder.delete
+            |> HttpBuilder.withQueryParams cascadeList
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| PUT - Upserts data to a dataset. If the `DataSet` has a key column, rows with the same key will be overwritten. If not, all rows will be appended to the existing `DataSet`.
@@ -196,11 +196,11 @@ createDataSetWithKey config dataSetName keyName =
         keyBody =
             Json.Encode.object [ ( "columns", encodeKeyColumnMetadata keyName ) ]
     in
-    (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
-        |> HttpBuilder.put
-        |> addHeaders config
-        |> HttpBuilder.withJsonBody keyBody
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
+            |> HttpBuilder.put
+            |> addHeaders config
+            |> HttpBuilder.withJsonBody keyBody
+            |> HttpBuilder.toRequest
 
 
 dataTypeToString : DataType -> String
@@ -219,11 +219,11 @@ setMissingValues config dataSetName missingValues =
         missingValuesBody =
             Json.Encode.object [ ( "missingValues", encodeMissingValues missingValues ) ]
     in
-    (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
-        |> HttpBuilder.put
-        |> addHeaders config
-        |> HttpBuilder.withJsonBody missingValuesBody
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/data/" ++ Http.encodeUri dataSetName)
+            |> HttpBuilder.put
+            |> addHeaders config
+            |> HttpBuilder.withJsonBody missingValuesBody
+            |> HttpBuilder.toRequest
 
 
 encodeMissingValues : List String -> Json.Encode.Value

--- a/src/Nexosis/Api/Data.elm
+++ b/src/Nexosis/Api/Data.elm
@@ -28,7 +28,7 @@ import Nexosis.Encoders.Columns exposing (encodeColumnMetadataList, encodeKeyCol
 import Nexosis.Types.Columns exposing (ColumnMetadata, DataType(..))
 import Nexosis.Types.DataSet exposing (DataSetData, DataSetList, DataSetName, DataSetStats, dataSetNameToString)
 import Nexosis.Types.SortParameters exposing (SortDirection(..), SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams)
+import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
 import Set
 
 
@@ -140,13 +140,6 @@ put config name content contentType =
         |> HttpBuilder.withBody (Http.stringBody contentType content)
         |> addHeaders config
         |> HttpBuilder.toRequest
-
-
-pageParams : Int -> Int -> List ( String, String )
-pageParams page pageSize =
-    [ ( "page", page |> toString )
-    , ( "pageSize", pageSize |> toString )
-    ]
 
 
 dateParams : Maybe ( String, String ) -> List ( String, String )

--- a/src/Nexosis/Api/Messages.elm
+++ b/src/Nexosis/Api/Messages.elm
@@ -1,29 +1,51 @@
 module Nexosis.Api.Messages exposing (get)
 
-{-| This endpoint returns static information about the metrics that the Api will calculate.
-This is really just to provide up to date text descriptions and names for metrics that may be shown to a user.
+{-| This endpoint returns messages based on the query parameters. All messages on an organization or related to a specific session or import can be queried.
 
 @docs get
 
 -}
 
 import Http
+import List
 import HttpBuilder exposing (withExpectJson)
-import Json.Decode exposing (Decoder, field, list, string)
-import Json.Decode.Pipeline exposing (decode, required)
 import Nexosis exposing (ClientConfig, getBaseUrl)
-import NexosisHelpers exposing (addHeaders)
+import NexosisHelpers exposing (addHeaders, pageParams)
 import Nexosis.Decoders.Message exposing (decodeMessageList)
-import Nexosis.Types.Message exposing (Message)
+import Nexosis.Types.Message exposing (MessageList, Severity)
+
+
+type alias MessageQuery =
+    { relatedId : Maybe String
+    , levels : Maybe (List Severity)
+    , page : Int
+    , pageSize : Int
+    }
 
 
 {-| GET a list of `Messages` based on a query
 -}
-get : ClientConfig -> Int -> Int -> Http.Request MessageList
-get config page pageSize =
+get : ClientConfig -> MessageQuery -> Http.Request MessageList
+get config query =
     let
+        encodeSeverity levels =
+            levels |> List.map (\l -> toString l |> String.toLower) |> String.join ","
+
         params =
-            pageParams page pageSize
+            (case ( query.relatedId, query.levels ) of
+                ( Just id, Just lvl ) ->
+                    [ ( "relatedId", id ), ( "levels", encodeSeverity lvl ) ]
+
+                ( Nothing, Just lvl ) ->
+                    [ ( "levels", encodeSeverity lvl ) ]
+
+                ( Just id, Nothing ) ->
+                    [ ( "relatedId", id ) ]
+
+                ( Nothing, Nothing ) ->
+                    []
+            )
+                ++ pageParams query.page query.pageSize
     in
         (getBaseUrl config ++ "/messages")
             |> HttpBuilder.get

--- a/src/Nexosis/Api/Messages.elm
+++ b/src/Nexosis/Api/Messages.elm
@@ -1,0 +1,32 @@
+module Nexosis.Api.Messages exposing (get)
+
+{-| This endpoint returns static information about the metrics that the Api will calculate.
+This is really just to provide up to date text descriptions and names for metrics that may be shown to a user.
+
+@docs get
+
+-}
+
+import Http
+import HttpBuilder exposing (withExpectJson)
+import Json.Decode exposing (Decoder, field, list, string)
+import Json.Decode.Pipeline exposing (decode, required)
+import Nexosis exposing (ClientConfig, getBaseUrl)
+import NexosisHelpers exposing (addHeaders)
+import Nexosis.Decoders.Message exposing (decodeMessageList)
+import Nexosis.Types.Message exposing (Message)
+
+
+{-| GET a list of `Messages` based on a query
+-}
+get : ClientConfig -> Int -> Int -> Http.Request MessageList
+get config page pageSize =
+    let
+        params =
+            pageParams page pageSize
+    in
+        (getBaseUrl config ++ "/messages")
+            |> HttpBuilder.get
+            |> withExpectJson decodeMessageList
+            |> addHeaders config
+            |> HttpBuilder.toRequest

--- a/src/Nexosis/Api/Messages.elm
+++ b/src/Nexosis/Api/Messages.elm
@@ -7,12 +7,12 @@ module Nexosis.Api.Messages exposing (get)
 -}
 
 import Http
-import List
 import HttpBuilder exposing (withExpectJson)
+import List
 import Nexosis exposing (ClientConfig, getBaseUrl)
-import NexosisHelpers exposing (addHeaders, pageParams)
 import Nexosis.Decoders.Message exposing (decodeMessageList)
 import Nexosis.Types.Message exposing (MessageList, Severity)
+import NexosisHelpers exposing (addHeaders, pageParams)
 
 
 type alias MessageQuery =
@@ -47,9 +47,9 @@ get config query =
             )
                 ++ pageParams query.page query.pageSize
     in
-        (getBaseUrl config ++ "/messages")
-            |> HttpBuilder.get
-            |> withExpectJson decodeMessageList
-            |> addHeaders config
-            |> HttpBuilder.withQueryParams params
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/messages")
+        |> HttpBuilder.get
+        |> withExpectJson decodeMessageList
+        |> addHeaders config
+        |> HttpBuilder.withQueryParams params
+        |> HttpBuilder.toRequest

--- a/src/Nexosis/Api/Messages.elm
+++ b/src/Nexosis/Api/Messages.elm
@@ -51,4 +51,5 @@ get config query =
             |> HttpBuilder.get
             |> withExpectJson decodeMessageList
             |> addHeaders config
+            |> HttpBuilder.withQueryParams params
             |> HttpBuilder.toRequest

--- a/src/Nexosis/Api/Models.elm
+++ b/src/Nexosis/Api/Models.elm
@@ -29,7 +29,7 @@ import Nexosis exposing (ClientConfig, getBaseUrl)
 import Nexosis.Decoders.Models exposing (decodeModel, decodeModelList, decodePredictions)
 import Nexosis.Types.Model exposing (ModelData, ModelList, PredictionResult)
 import Nexosis.Types.SortParameters exposing (SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams)
+import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
 
 
 {-| GET a listing of `Models`, with page limits and sorting information.
@@ -41,19 +41,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-    (getBaseUrl config ++ "/models")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeModelList
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
-
-
-pageParams : Int -> Int -> List ( String, String )
-pageParams page pageSize =
-    [ ( "page", page |> toString )
-    , ( "pageSize", pageSize |> toString )
-    ]
+        (getBaseUrl config ++ "/models")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeModelList
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| DELETE a single `Model`.

--- a/src/Nexosis/Api/Models.elm
+++ b/src/Nexosis/Api/Models.elm
@@ -29,7 +29,7 @@ import Nexosis exposing (ClientConfig, getBaseUrl)
 import Nexosis.Decoders.Models exposing (decodeModel, decodeModelList, decodePredictions)
 import Nexosis.Types.Model exposing (ModelData, ModelList, PredictionResult)
 import Nexosis.Types.SortParameters exposing (SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
+import NexosisHelpers exposing (addHeaders, pageParams, sortParams)
 
 
 {-| GET a listing of `Models`, with page limits and sorting information.
@@ -41,12 +41,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-        (getBaseUrl config ++ "/models")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeModelList
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/models")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeModelList
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| DELETE a single `Model`.

--- a/src/Nexosis/Api/Sessions.elm
+++ b/src/Nexosis/Api/Sessions.elm
@@ -54,7 +54,7 @@ import Nexosis.Types.DistanceMetric exposing (DistanceMetrics)
 import Nexosis.Types.PredictionDomain exposing (PredictionDomain)
 import Nexosis.Types.Session exposing (ResultInterval, SessionData, SessionList, SessionResults)
 import Nexosis.Types.SortParameters exposing (SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams)
+import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
 import Time.ZonedDateTime exposing (ZonedDateTime, toISO8601)
 
 
@@ -67,12 +67,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-    (getBaseUrl config ++ "/sessions")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeSessionList
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeSessionList
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET results of a completed `Session`.
@@ -83,12 +83,12 @@ results config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeSessionResults
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeSessionResults
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET the results as a CSV file, in a `String`.
@@ -104,13 +104,6 @@ resultsCsv config sessionId =
         |> HttpBuilder.toRequest
 
 
-pageParams : Int -> Int -> List ( String, String )
-pageParams page pageSize =
-    [ ( "page", page |> toString )
-    , ( "pageSize", pageSize |> toString )
-    ]
-
-
 {-| GET a Confusion Matrix generated from the results of a `Classification` `Session`.
 -}
 getConfusionMatrix : ClientConfig -> String -> Int -> Int -> Http.Request ConfusionMatrix
@@ -119,12 +112,12 @@ getConfusionMatrix config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/confusionmatrix")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeConfusionMatrix
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/confusionmatrix")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeConfusionMatrix
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET a list of `Session` filtered by the `DataSetName`.
@@ -135,12 +128,12 @@ getForDataset config dataSetName =
         params =
             [ ( "dataSetName", dataSetNameToString dataSetName ) ]
     in
-    (getBaseUrl config ++ "/sessions")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeSessionList
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeSessionList
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| DELETE a single `Session`.
@@ -186,12 +179,12 @@ postModel config sessionRequest =
         requestBody =
             encodeModelSessionRequest sessionRequest
     in
-    (getBaseUrl config ++ "/sessions/model")
-        |> HttpBuilder.post
-        |> HttpBuilder.withExpectJson decodeSession
-        |> addHeaders config
-        |> HttpBuilder.withJsonBody requestBody
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/model")
+            |> HttpBuilder.post
+            |> HttpBuilder.withExpectJson decodeSession
+            |> addHeaders config
+            |> HttpBuilder.withJsonBody requestBody
+            |> HttpBuilder.toRequest
 
 
 encodeModelSessionRequest : ModelSessionRequest -> Encode.Value
@@ -230,12 +223,12 @@ postForecast config sessionRequest =
         requestBody =
             encodeForecastSessionRequest sessionRequest
     in
-    (getBaseUrl config ++ "/sessions/forecast")
-        |> HttpBuilder.post
-        |> HttpBuilder.withExpectJson decodeSession
-        |> addHeaders config
-        |> HttpBuilder.withJsonBody requestBody
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/forecast")
+            |> HttpBuilder.post
+            |> HttpBuilder.withExpectJson decodeSession
+            |> addHeaders config
+            |> HttpBuilder.withJsonBody requestBody
+            |> HttpBuilder.toRequest
 
 
 encodeForecastSessionRequest : ForecastSessionRequest -> Encode.Value
@@ -276,12 +269,12 @@ postImpact config sessionRequest =
         requestBody =
             encodeImpactSessionRequest sessionRequest
     in
-    (getBaseUrl config ++ "/sessions/impact")
-        |> HttpBuilder.post
-        |> HttpBuilder.withExpectJson decodeSession
-        |> addHeaders config
-        |> HttpBuilder.withJsonBody requestBody
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/impact")
+            |> HttpBuilder.post
+            |> HttpBuilder.withExpectJson decodeSession
+            |> addHeaders config
+            |> HttpBuilder.withJsonBody requestBody
+            |> HttpBuilder.toRequest
 
 
 encodeImpactSessionRequest : ImpactSessionRequest -> Encode.Value
@@ -318,10 +311,10 @@ encodeExtraParameters sessionRequest =
                 |> Maybe.map Encode.bool
                 |> Maybe.withDefault Encode.null
     in
-    Encode.object
-        [ ( "balance", balance )
-        , ( "containsAnomalies", anomalies )
-        ]
+        Encode.object
+            [ ( "balance", balance )
+            , ( "containsAnomalies", anomalies )
+            ]
 
 
 {-| GET the Mahalanobis Distances calculated by an Anomaly Detection `Session` as a CSV String.
@@ -332,13 +325,13 @@ getDistanceMetricsCsv config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectString
-        |> HttpBuilder.withHeader "Accept" "text/csv"
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectString
+            |> HttpBuilder.withHeader "Accept" "text/csv"
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest
 
 
 {-| GET the Mahalanobis Distances calculated by an Anomaly Detection `Session`.
@@ -349,9 +342,9 @@ getDistanceMetrics config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
-        |> HttpBuilder.get
-        |> HttpBuilder.withExpectJson decodeDistanceMetrics
-        |> HttpBuilder.withQueryParams params
-        |> addHeaders config
-        |> HttpBuilder.toRequest
+        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
+            |> HttpBuilder.get
+            |> HttpBuilder.withExpectJson decodeDistanceMetrics
+            |> HttpBuilder.withQueryParams params
+            |> addHeaders config
+            |> HttpBuilder.toRequest

--- a/src/Nexosis/Api/Sessions.elm
+++ b/src/Nexosis/Api/Sessions.elm
@@ -54,7 +54,7 @@ import Nexosis.Types.DistanceMetric exposing (DistanceMetrics)
 import Nexosis.Types.PredictionDomain exposing (PredictionDomain)
 import Nexosis.Types.Session exposing (ResultInterval, SessionData, SessionList, SessionResults)
 import Nexosis.Types.SortParameters exposing (SortParameters)
-import NexosisHelpers exposing (addHeaders, sortParams, pageParams)
+import NexosisHelpers exposing (addHeaders, pageParams, sortParams)
 import Time.ZonedDateTime exposing (ZonedDateTime, toISO8601)
 
 
@@ -67,12 +67,12 @@ get config page pageSize sorting =
             pageParams page pageSize
                 ++ sortParams sorting
     in
-        (getBaseUrl config ++ "/sessions")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeSessionList
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeSessionList
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET results of a completed `Session`.
@@ -83,12 +83,12 @@ results config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeSessionResults
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeSessionResults
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET the results as a CSV file, in a `String`.
@@ -112,12 +112,12 @@ getConfusionMatrix config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/confusionmatrix")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeConfusionMatrix
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/confusionmatrix")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeConfusionMatrix
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET a list of `Session` filtered by the `DataSetName`.
@@ -128,12 +128,12 @@ getForDataset config dataSetName =
         params =
             [ ( "dataSetName", dataSetNameToString dataSetName ) ]
     in
-        (getBaseUrl config ++ "/sessions")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeSessionList
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeSessionList
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| DELETE a single `Session`.
@@ -179,12 +179,12 @@ postModel config sessionRequest =
         requestBody =
             encodeModelSessionRequest sessionRequest
     in
-        (getBaseUrl config ++ "/sessions/model")
-            |> HttpBuilder.post
-            |> HttpBuilder.withExpectJson decodeSession
-            |> addHeaders config
-            |> HttpBuilder.withJsonBody requestBody
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/model")
+        |> HttpBuilder.post
+        |> HttpBuilder.withExpectJson decodeSession
+        |> addHeaders config
+        |> HttpBuilder.withJsonBody requestBody
+        |> HttpBuilder.toRequest
 
 
 encodeModelSessionRequest : ModelSessionRequest -> Encode.Value
@@ -223,12 +223,12 @@ postForecast config sessionRequest =
         requestBody =
             encodeForecastSessionRequest sessionRequest
     in
-        (getBaseUrl config ++ "/sessions/forecast")
-            |> HttpBuilder.post
-            |> HttpBuilder.withExpectJson decodeSession
-            |> addHeaders config
-            |> HttpBuilder.withJsonBody requestBody
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/forecast")
+        |> HttpBuilder.post
+        |> HttpBuilder.withExpectJson decodeSession
+        |> addHeaders config
+        |> HttpBuilder.withJsonBody requestBody
+        |> HttpBuilder.toRequest
 
 
 encodeForecastSessionRequest : ForecastSessionRequest -> Encode.Value
@@ -269,12 +269,12 @@ postImpact config sessionRequest =
         requestBody =
             encodeImpactSessionRequest sessionRequest
     in
-        (getBaseUrl config ++ "/sessions/impact")
-            |> HttpBuilder.post
-            |> HttpBuilder.withExpectJson decodeSession
-            |> addHeaders config
-            |> HttpBuilder.withJsonBody requestBody
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/impact")
+        |> HttpBuilder.post
+        |> HttpBuilder.withExpectJson decodeSession
+        |> addHeaders config
+        |> HttpBuilder.withJsonBody requestBody
+        |> HttpBuilder.toRequest
 
 
 encodeImpactSessionRequest : ImpactSessionRequest -> Encode.Value
@@ -311,10 +311,10 @@ encodeExtraParameters sessionRequest =
                 |> Maybe.map Encode.bool
                 |> Maybe.withDefault Encode.null
     in
-        Encode.object
-            [ ( "balance", balance )
-            , ( "containsAnomalies", anomalies )
-            ]
+    Encode.object
+        [ ( "balance", balance )
+        , ( "containsAnomalies", anomalies )
+        ]
 
 
 {-| GET the Mahalanobis Distances calculated by an Anomaly Detection `Session` as a CSV String.
@@ -325,13 +325,13 @@ getDistanceMetricsCsv config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectString
-            |> HttpBuilder.withHeader "Accept" "text/csv"
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectString
+        |> HttpBuilder.withHeader "Accept" "text/csv"
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest
 
 
 {-| GET the Mahalanobis Distances calculated by an Anomaly Detection `Session`.
@@ -342,9 +342,9 @@ getDistanceMetrics config sessionId page pageSize =
         params =
             pageParams page pageSize
     in
-        (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
-            |> HttpBuilder.get
-            |> HttpBuilder.withExpectJson decodeDistanceMetrics
-            |> HttpBuilder.withQueryParams params
-            |> addHeaders config
-            |> HttpBuilder.toRequest
+    (getBaseUrl config ++ "/sessions/" ++ sessionId ++ "/results/mahalanobisdistances")
+        |> HttpBuilder.get
+        |> HttpBuilder.withExpectJson decodeDistanceMetrics
+        |> HttpBuilder.withQueryParams params
+        |> addHeaders config
+        |> HttpBuilder.toRequest

--- a/src/Nexosis/Decoders/Import.elm
+++ b/src/Nexosis/Decoders/Import.elm
@@ -4,7 +4,7 @@ import Json.Decode exposing (Decoder, andThen, dict, fail, list, nullable, strin
 import Json.Decode.Pipeline exposing (decode, required)
 import Nexosis.Decoders.Columns exposing (decodeColumnMetadata)
 import Nexosis.Decoders.DataSet exposing (dataSetNameDecoder)
-import Nexosis.Decoders.Message exposing (decodeMessage)
+import Nexosis.Decoders.Message exposing (decodeObjectMessage)
 import Nexosis.Decoders.Status exposing (decodeHistoryRecord, decodeStatus)
 import Nexosis.Types.Import exposing (ImportDetail, ImportType(..))
 import Time.DateTime exposing (DateTime, fromISO8601)
@@ -20,7 +20,7 @@ decodeImportDetail =
         |> required "parameters" (dict (nullable string))
         |> required "requestedDate" decodeDate
         |> required "statusHistory" (list decodeHistoryRecord)
-        |> required "messages" (list decodeMessage)
+        |> required "messages" (list decodeObjectMessage)
         |> required "columns" decodeColumnMetadata
 
 

--- a/src/Nexosis/Decoders/Message.elm
+++ b/src/Nexosis/Decoders/Message.elm
@@ -1,14 +1,38 @@
-module Nexosis.Decoders.Message exposing (decodeMessage, decodeSeverity)
+module Nexosis.Decoders.Message exposing (decodeObjectMessage, decodeMessageList, decodeSeverity)
 
-import Json.Decode exposing (Decoder, andThen, fail, field, map2, string, succeed)
-import Nexosis.Types.Message exposing (Message, Severity(..))
+import Json.Decode exposing (Decoder, andThen, fail, field, map2, string, succeed, list, int)
+import Json.Decode.Pipeline exposing (decode, required)
+import Nexosis.Types.Message exposing (Message, MessageList, ObjectMessage, Severity(..))
+
+
+decodeObjectMessage : Decoder ObjectMessage
+decodeObjectMessage =
+    map2 ObjectMessage
+        (field "severity" decodeSeverity)
+        (field "message" string)
+
+
+decodeMessageList : Decoder MessageList
+decodeMessageList =
+    decode MessageList
+        |> required "items" (list decodeMessage)
+        |> required "pageNumber" int
+        |> required "totalPages" int
+        |> required "pageSize" int
+        |> required "totalCount" int
 
 
 decodeMessage : Decoder Message
 decodeMessage =
-    map2 Message
-        (field "severity" decodeSeverity)
-        (field "message" string)
+    decode Message
+        |> required "messageId" string
+        |> required "content" string
+        |> required "severity" decodeSeverity
+        |> required "userId" string
+        |> required "organizationId" string
+        |> required "createAt" string
+        |> required "relatedId" string
+        |> required "relatedTo" string
 
 
 decodeSeverity : Decoder Severity
@@ -17,6 +41,9 @@ decodeSeverity =
         |> andThen
             (\severity ->
                 case severity of
+                    "status" ->
+                        succeed Status
+
                     "debug" ->
                         succeed Debug
 

--- a/src/Nexosis/Decoders/Message.elm
+++ b/src/Nexosis/Decoders/Message.elm
@@ -1,6 +1,6 @@
-module Nexosis.Decoders.Message exposing (decodeObjectMessage, decodeMessageList, decodeSeverity)
+module Nexosis.Decoders.Message exposing (decodeMessageList, decodeObjectMessage, decodeSeverity)
 
-import Json.Decode exposing (Decoder, andThen, fail, field, map2, string, succeed, list, int)
+import Json.Decode exposing (Decoder, andThen, fail, field, int, list, map2, string, succeed)
 import Json.Decode.Pipeline exposing (decode, required)
 import Nexosis.Types.Message exposing (Message, MessageList, ObjectMessage, Severity(..))
 

--- a/src/Nexosis/Decoders/Models.elm
+++ b/src/Nexosis/Decoders/Models.elm
@@ -7,7 +7,7 @@ import Nexosis.Decoders.Columns exposing (decodeColumnMetadata)
 import Nexosis.Decoders.Data exposing (decodeData)
 import Nexosis.Decoders.Date exposing (decodeDate)
 import Nexosis.Decoders.Link exposing (decodeLink)
-import Nexosis.Decoders.Message exposing (decodeMessage)
+import Nexosis.Decoders.Message exposing (decodeObjectMessage)
 import Nexosis.Decoders.PredictionDomain exposing (decodePredictionDomain)
 import Nexosis.Types.Model exposing (ModelData, ModelList, PredictionResult)
 
@@ -42,4 +42,4 @@ decodePredictions : Decoder PredictionResult
 decodePredictions =
     decode PredictionResult
         |> required "data" decodeData
-        |> required "messages" (list decodeMessage)
+        |> required "messages" (list decodeObjectMessage)

--- a/src/Nexosis/Decoders/Session.elm
+++ b/src/Nexosis/Decoders/Session.elm
@@ -7,7 +7,7 @@ import Nexosis.Decoders.Columns exposing (decodeColumnMetadata)
 import Nexosis.Decoders.Data exposing (decodeData)
 import Nexosis.Decoders.Date exposing (decodeDate)
 import Nexosis.Decoders.Link exposing (decodeLink)
-import Nexosis.Decoders.Message exposing (decodeMessage)
+import Nexosis.Decoders.Message exposing (decodeObjectMessage)
 import Nexosis.Decoders.PredictionDomain exposing (decodePredictionDomain)
 import Nexosis.Decoders.Status exposing (decodeHistoryRecord, decodeStatus)
 import Nexosis.Types.Session exposing (ResultInterval(..), SessionData, SessionList, SessionResults)
@@ -34,7 +34,7 @@ decodeSession =
         |> required "requestedDate" decodeDate
         |> required "statusHistory" (Decode.list decodeHistoryRecord)
         |> required "extraParameters" (Decode.dict (Decode.oneOf [ Decode.string, Decode.bool |> Decode.andThen (\b -> succeed (toString b)) ]))
-        |> required "messages" (Decode.list decodeMessage)
+        |> required "messages" (Decode.list decodeObjectMessage)
         |> required "name" Decode.string
         |> required "dataSourceName" Decode.string
         |> optional "targetColumn" (Decode.map Just string) Nothing

--- a/src/Nexosis/Types/Import.elm
+++ b/src/Nexosis/Types/Import.elm
@@ -9,7 +9,7 @@ module Nexosis.Types.Import exposing (ImportDetail, ImportType(..))
 import Dict exposing (Dict)
 import Nexosis.Types.Columns exposing (ColumnMetadata)
 import Nexosis.Types.DataSet exposing (DataSetName)
-import Nexosis.Types.Message exposing (Message)
+import Nexosis.Types.Message exposing (ObjectMessage)
 import Nexosis.Types.Status exposing (HistoryRecord, Status)
 import Time.DateTime exposing (DateTime)
 
@@ -24,7 +24,7 @@ type alias ImportDetail =
     , parameters : Dict String (Maybe String)
     , requestedDate : DateTime
     , statusHistory : List HistoryRecord
-    , messages : List Message
+    , messages : List ObjectMessage
     , columns : List ColumnMetadata
     }
 

--- a/src/Nexosis/Types/Message.elm
+++ b/src/Nexosis/Types/Message.elm
@@ -1,22 +1,52 @@
-module Nexosis.Types.Message exposing (Message, Severity(..))
+module Nexosis.Types.Message exposing (ObjectMessage, Message, MessageList, Severity(..))
 
 {-| Messages are returned on many different Api endpoints. Generally, these show additional information about an Api Resource.
+Addditionally, you can query for all messages on an organization, session, or import.
 
-@docs Message, Severity
+@docs ObjectMessage, Message, Severity, MessageList
 
 -}
 
 
-{-| -}
-type alias Message =
+{-| Message as given on an object
+-}
+type alias ObjectMessage =
     { severity : Severity
     , message : String
     }
 
 
-{-| -}
+{-| Returned from `/messages` endpoint called by [Nexosis.Api.Messages.get](Nexosis-Api-Messages#get)
+A List of [Message](#Message), with paging information.
+-}
+type alias MessageList =
+    { items : List Message
+    , pageNumber : Int
+    , totalPages : Int
+    , pageSize : Int
+    , totalCount : Int
+    }
+
+
+{-| Detailed Message information from /messages endpoint.
+-}
+type alias Message =
+    { messageId : String
+    , content : String
+    , severity : Severity
+    , userId : String
+    , organizationId : String
+    , createdAt : String
+    , relatedId : String
+    , relatedTo : String
+    }
+
+
+{-| Message Severity
+-}
 type Severity
-    = Debug
+    = Status
+    | Debug
     | Informational
     | Warning
     | Error

--- a/src/Nexosis/Types/Message.elm
+++ b/src/Nexosis/Types/Message.elm
@@ -1,4 +1,4 @@
-module Nexosis.Types.Message exposing (ObjectMessage, Message, MessageList, Severity(..))
+module Nexosis.Types.Message exposing (Message, MessageList, ObjectMessage, Severity(..))
 
 {-| Messages are returned on many different Api endpoints. Generally, these show additional information about an Api Resource.
 Addditionally, you can query for all messages on an organization, session, or import.

--- a/src/Nexosis/Types/Model.elm
+++ b/src/Nexosis/Types/Model.elm
@@ -14,7 +14,7 @@ import Dict exposing (Dict)
 import Nexosis.Types.Algorithm exposing (Algorithm)
 import Nexosis.Types.Columns exposing (ColumnMetadata)
 import Nexosis.Types.Link exposing (Link)
-import Nexosis.Types.Message exposing (Message)
+import Nexosis.Types.Message exposing (ObjectMessage)
 import Nexosis.Types.PredictionDomain exposing (PredictionDomain)
 import Time.ZonedDateTime exposing (ZonedDateTime)
 
@@ -52,5 +52,5 @@ type alias ModelList =
 -}
 type alias PredictionResult =
     { data : List (Dict String String)
-    , messages : List Message
+    , messages : List ObjectMessage
     }

--- a/src/Nexosis/Types/Session.elm
+++ b/src/Nexosis/Types/Session.elm
@@ -14,7 +14,7 @@ import Dict exposing (Dict)
 import Nexosis.Types.Algorithm exposing (Algorithm)
 import Nexosis.Types.Columns exposing (ColumnMetadata)
 import Nexosis.Types.Link exposing (Link)
-import Nexosis.Types.Message exposing (Message)
+import Nexosis.Types.Message exposing (ObjectMessage)
 import Nexosis.Types.PredictionDomain exposing (PredictionDomain)
 import Nexosis.Types.Status exposing (HistoryRecord, Status)
 import Time.ZonedDateTime exposing (ZonedDateTime)
@@ -35,7 +35,7 @@ type alias SessionData =
     , requestedDate : ZonedDateTime
     , statusHistory : List HistoryRecord
     , extraParameters : Dict String String
-    , messages : List Message
+    , messages : List ObjectMessage
     , name : String
     , dataSourceName : String
     , targetColumn : Maybe String

--- a/src/NexosisHelpers.elm
+++ b/src/NexosisHelpers.elm
@@ -1,4 +1,4 @@
-module NexosisHelpers exposing (addHeaders, sortParams)
+module NexosisHelpers exposing (addHeaders, sortParams, pageParams)
 
 import HttpBuilder exposing (RequestBuilder, withBearerToken, withHeader)
 import Nexosis exposing (ClientConfig, withAppHeader, withAuthorization)
@@ -19,4 +19,11 @@ sortParams { sortName, direction } =
         else
             "desc"
       )
+    ]
+
+
+pageParams : Int -> Int -> List ( String, String )
+pageParams page pageSize =
+    [ ( "page", page |> toString )
+    , ( "pageSize", pageSize |> toString )
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,9 +425,9 @@ elm-analyse@^0.13.3:
     sums "0.2.4"
     ws "3.3.1"
 
-elm-format@^0.6.1-alpha:
-  version "0.6.1-alpha"
-  resolved "https://registry.yarnpkg.com/elm-format/-/elm-format-0.6.1-alpha.tgz#daeffe95238cb8ce0d7fc6afb5047bcdd14ad7d7"
+elm-format@^0.7.0-exp:
+  version "0.7.0-exp"
+  resolved "https://registry.yarnpkg.com/elm-format/-/elm-format-0.7.0-exp.tgz#75b9d9f3f0b67195b44e804fce5a6be0f45af408"
   dependencies:
     binwrap "^0.1.4"
 


### PR DESCRIPTION
There is just one endpoint to add here. So that's what was done. The interesting change is that I renamed `Message` to `ObjectMessage` so the messages endpoint can return a list of `Message`.

I also extracted the `pageParams` function into the helpers module.